### PR TITLE
Fix EM6 errors and enable plugin for 3.23.90 and 3.24

### DIFF
--- a/simple-dock@nothing.org/atomappdisplay.js
+++ b/simple-dock@nothing.org/atomappdisplay.js
@@ -235,9 +235,7 @@ const AtomAppIconMenu = new Lang.Class({
     },
 
     _appendActions: function (appInfo, actions, windows) {
-
-        let i = 0;
-
+        let i;
         // Add custom application 'actions'
         this._actionMenuItems = new Array(actions.length);
         for (i = 0; i < actions.length; i++) {
@@ -299,7 +297,7 @@ const AtomAppIconMenu = new Lang.Class({
     _appendQuit: function () {
 
         // Add 'quit' button
-        this._quitMenuItem = this._appendMenuItem(_("Quit"))
+        this._quitMenuItem = this._appendMenuItem(_("Quit"));
         this._quitMenuItem.connect('activate', (actor, event) => {
             let app = this._source.app;
             let wins = app.get_windows();

--- a/simple-dock@nothing.org/atomdash.js
+++ b/simple-dock@nothing.org/atomdash.js
@@ -229,7 +229,6 @@ const AtomDashActor = new Lang.Class({
 
         this.set_allocation(box, flags);
 
-        let t;
         let [appIcons, showAppsButton] = this.get_children();
         let [t, showAppsNatWidth] = showAppsButton.get_preferred_width(availWidth);
 
@@ -254,13 +253,15 @@ const AtomDashActor = new Lang.Class({
         // as our natural height, so we chain up to StWidget (which
         // then calls BoxLayout), but we only request the showApps
         // button as the minimum size
-
         let t;
-        let [t, natWidth] = this.parent(forHeight);
+        let natWidth;
+        let showAppsButton;
+        let minWidth;
+        [t, natWidth] = this.parent(forHeight);
         let themeNode = this.get_theme_node();
         let adjustedForHeight = themeNode.adjust_for_height(forHeight);
-        let [t, showAppsButton] = this.get_children();
-        let [minWidth, t] = showAppsButton.get_preferred_width(adjustedForHeight);
+        [t, showAppsButton] = this.get_children();
+        [minWidth, t] = showAppsButton.get_preferred_width(adjustedForHeight);
 
         [minWidth, t] = themeNode.adjust_preferred_width(minWidth, natWidth);
 
@@ -700,7 +701,9 @@ const AtomDash = new Lang.Class({
         let newApps = [];
 
         for (let id in favorites) {
-            newApps.push(favorites[id]);
+            if (favorites.hasOwnProperty(id)) {
+                newApps.push(favorites[id]);
+            }
         }
 
         for (let i = 0; i < running.length; i++) {
@@ -1024,8 +1027,8 @@ const AtomDash = new Lang.Class({
 
     // Keep ShowAppsButton status in sync with the overview status
     _syncShowAppsButtonToggled: function() {
-        let status = Main.overview.viewSelector._showAppsButton.checked;
-        this.showAppsButton.checked = status;
+        let showStatus = Main.overview.viewSelector._showAppsButton.checked;
+        this.showAppsButton.checked = showStatus;
     },
 
     setShowAppsButton: function(show) {

--- a/simple-dock@nothing.org/atomdock.js
+++ b/simple-dock@nothing.org/atomdock.js
@@ -398,8 +398,13 @@ const AtomDock = new Lang.Class({
             goDn = true;
             break;
         }
-        if (goUp) { diff = -1; }
-        if (goDn) { diff = +1; }
+        var diff = 0;
+        if (goUp) {
+            diff = -1;
+        }
+        if (goDn) {
+            diff = +1;
+        }
 
         // Get running windows (and active one)
         let children = this.getRunningWindows();
@@ -425,10 +430,9 @@ const AtomDock = new Lang.Class({
     getRunningWindows: function () {
         let apps = Shell.AppSystem.get_default().get_running().sort();
         let windows = [];
-        let counter = 0;
-
+        let counter;
         for (counter = 0; counter < apps.length; counter = counter + 1) {
-            appWindows = apps[counter].get_windows().filter(function(w) { return !w.skip_taskbar; }).sort(function (a, b) {
+            var appWindows = apps[counter].get_windows().filter(function(w) { return !w.skip_taskbar; }).sort(function (a, b) {
                 return a.get_stable_sequence() - b.get_stable_sequence();
             });
             windows = windows.concat(appWindows);

--- a/simple-dock@nothing.org/convenience.js
+++ b/simple-dock@nothing.org/convenience.js
@@ -97,7 +97,9 @@ const GlobalSignalHandler = new Lang.Class({
 
     disconnect: function() {
         for (let label in this._signals) {
-            this.disconnectWithLabel(label);
+            if (this._signals.hasOwnProperty(label)) {
+                this.disconnectWithLabel(label);
+            }
         }
     },
 

--- a/simple-dock@nothing.org/metadata.json
+++ b/simple-dock@nothing.org/metadata.json
@@ -7,7 +7,9 @@
     "3.18", 
     "3.17.91", 
     "3.20", 
-    "3.22"
+    "3.22",
+    "3.23.90",
+    "3.24"
   ], 
   "url": "https://github.com/optimisme/gnome-shell-simple-dock", 
   "uuid": "simple-dock@nothing.org", 

--- a/simple-dock@nothing.org/prefs.js
+++ b/simple-dock@nothing.org/prefs.js
@@ -101,7 +101,7 @@ function buildPrefsWidget() {
     });
 	infoLabel.set_justify(Gtk.Justification.CENTER);
 
-    grid = new Gtk.Grid({ column_spacing: 25, halign: Gtk.Align.CENTER, margin: 10, row_spacing: 10 });
+    var grid = new Gtk.Grid({ column_spacing: 25, halign: Gtk.Align.CENTER, margin: 10, row_spacing: 10 });
     grid.set_border_width(15);
 
     grid.attach(showAppsLabel,      0, 1, 1, 1);


### PR DESCRIPTION
Replaces #16 

This fixes the errors that make the plugin not work on gnome-shell 3.23.90-3.24